### PR TITLE
Fix #62: Update MJCF files to support MuJoCo >= 3.2.4 (remove elasticity.solid plugin)

### DIFF
--- a/deformable_gym/assets/objects/mjcf/insole_fixed.xml
+++ b/deformable_gym/assets/objects/mjcf/insole_fixed.xml
@@ -5,7 +5,7 @@
                 <body name="insole_fixed">
                         <flexcomp name="insole" mass=".5" dim="3" type="gmsh" file="insole.msh" rgba=".1 .9 .1 1" radius="0.001">
                                 <edge equality="true" />
-                                <elasticity young="1e4" damping="1e-4" poisson="0.1"/>
+                                <elasticity young="1e4" damping="1e-4" poisson="0.1" />
                         </flexcomp>
                 </body>
         </worldbody>

--- a/deformable_gym/assets/objects/mjcf/insole_fixed.xml
+++ b/deformable_gym/assets/objects/mjcf/insole_fixed.xml
@@ -1,29 +1,22 @@
 <mujoco>
-	<!-- <include file="floor.xml"/> -->
-	<compiler meshdir="../../meshes/" />
-	<extension>
-		<plugin plugin="mujoco.elasticity.solid" />
-	</extension>
-	<worldbody>
-		<body name="insole_fixed">
-			<flexcomp name="insole" mass=".5" dim="3" type="gmsh" file="insole.msh" rgba=".1 .9 .1 1" radius="0.001">
-				<edge equality="true" />
-				<plugin plugin="mujoco.elasticity.solid">
-					<config key="young" value="1e4" />
-					<config key="poisson" value="0.1" />
-					<config key="damping" value="1e-4" />
-				</plugin>
-			</flexcomp>
-		</body>
-	</worldbody>
-	<equality>
-		<weld name="fix_1" body1="insole_27" body2="insole_fixed" />
-		<weld name="fix_2" body1="insole_44" body2="insole_fixed" />
-		<weld name="fix_3" body1="insole_37" body2="insole_fixed" />
-		<weld name="fix_4" body1="insole_35" body2="insole_fixed" />
-		<weld name="fix_5" body1="insole_43" body2="insole_fixed" />
-		<weld name="fix_6" body1="insole_1" body2="insole_fixed" />
-		<weld name="fix_7" body1="insole_32" body2="insole_fixed" />
-		<weld name="fix_8" body1="insole_69" body2="insole_fixed" />
-	</equality>
+        <!-- <include file="floor.xml"/> -->
+        <compiler meshdir="../../meshes/" />
+        <worldbody>
+                <body name="insole_fixed">
+                        <flexcomp name="insole" mass=".5" dim="3" type="gmsh" file="insole.msh" rgba=".1 .9 .1 1" radius="0.001">
+                                <edge equality="true" />
+                                <elasticity young="1e4" damping="1e-4" poisson="0.1"/>
+                        </flexcomp>
+                </body>
+        </worldbody>
+        <equality>
+                <weld name="fix_1" body1="insole_27" body2="insole_fixed" />
+                <weld name="fix_2" body1="insole_44" body2="insole_fixed" />
+                <weld name="fix_3" body1="insole_37" body2="insole_fixed" />
+                <weld name="fix_4" body1="insole_35" body2="insole_fixed" />
+                <weld name="fix_5" body1="insole_43" body2="insole_fixed" />
+                <weld name="fix_6" body1="insole_1" body2="insole_fixed" />
+                <weld name="fix_7" body1="insole_32" body2="insole_fixed" />
+                <weld name="fix_8" body1="insole_69" body2="insole_fixed" />
+        </equality>
 </mujoco>

--- a/deformable_gym/assets/objects/mjcf/pillow_fixed.xml
+++ b/deformable_gym/assets/objects/mjcf/pillow_fixed.xml
@@ -5,7 +5,7 @@
                 <body name="pillow_fixed" pos="0 0 1" quat="1 0 0 1">
                         <flexcomp name="pillow" mass="1" dim="3" type="gmsh" scale=".7 .7 .7" file="pillow_small.msh" rgba=".1 .9 .1 1" radius="0.001">
                                 <edge equality="true" />
-                                <elasticity young="2000" damping="1e-4" poisson="0.1"/>
+                                <elasticity young="2000" damping="1e-4" poisson="0.1" />
                         </flexcomp>
                 </body>
         </worldbody>

--- a/deformable_gym/assets/objects/mjcf/pillow_fixed.xml
+++ b/deformable_gym/assets/objects/mjcf/pillow_fixed.xml
@@ -1,29 +1,22 @@
 <mujoco>
-	<!-- <include file="floor.xml" /> -->
-	<compiler meshdir="../../meshes/" />
-	<extension>
-		<plugin plugin="mujoco.elasticity.solid" />
-	</extension>
-	<worldbody>
-		<body name="pillow_fixed" pos="0 0 1" quat="1 0 0 1">
-			<flexcomp name="pillow" mass="1" dim="3" type="gmsh" scale=".7 .7 .7" file="pillow_small.msh" rgba=".1 .9 .1 1" radius="0.001">
-				<edge equality="true" />
-				<plugin plugin="mujoco.elasticity.solid">
-					<config key="young" value="2000" />
-					<config key="poisson" value="0.1" />
-					<config key="damping" value="1e-4" />
-				</plugin>
-			</flexcomp>
-		</body>
-	</worldbody>
-	<equality>
-		<weld name="fix_1" body1="pillow_94" body2="pillow_fixed" />
-		<weld name="fix_2" body1="pillow_8" body2="pillow_fixed" />
-		<weld name="fix_3" body1="pillow_9" body2="pillow_fixed" />
-		<weld name="fix_4" body1="pillow_2" body2="pillow_fixed" />
-		<weld name="fix_5" body1="pillow_58" body2="pillow_fixed" />
-		<weld name="fix_6" body1="pillow_69" body2="pillow_fixed" />
-		<weld name="fix_7" body1="pillow_116" body2="pillow_fixed" />
-		<weld name="fix_8" body1="pillow_47" body2="pillow_fixed" />
-	</equality>
+        <!-- <include file="floor.xml" /> -->
+        <compiler meshdir="../../meshes/" />
+        <worldbody>
+                <body name="pillow_fixed" pos="0 0 1" quat="1 0 0 1">
+                        <flexcomp name="pillow" mass="1" dim="3" type="gmsh" scale=".7 .7 .7" file="pillow_small.msh" rgba=".1 .9 .1 1" radius="0.001">
+                                <edge equality="true" />
+                                <elasticity young="2000" damping="1e-4" poisson="0.1"/>
+                        </flexcomp>
+                </body>
+        </worldbody>
+        <equality>
+                <weld name="fix_1" body1="pillow_94" body2="pillow_fixed" />
+                <weld name="fix_2" body1="pillow_8" body2="pillow_fixed" />
+                <weld name="fix_3" body1="pillow_9" body2="pillow_fixed" />
+                <weld name="fix_4" body1="pillow_2" body2="pillow_fixed" />
+                <weld name="fix_5" body1="pillow_58" body2="pillow_fixed" />
+                <weld name="fix_6" body1="pillow_69" body2="pillow_fixed" />
+                <weld name="fix_7" body1="pillow_116" body2="pillow_fixed" />
+                <weld name="fix_8" body1="pillow_47" body2="pillow_fixed" />
+        </equality>
 </mujoco>


### PR DESCRIPTION
## Summary

Fixes #62

The `mujoco.elasticity.solid` plugin was removed in MuJoCo 3.2.4 and its functionality was moved directly into the engine. This PR updates the two deformable object MJCF files to use the new built-in `<elasticity>` element instead of the plugin-based approach.

## Changes

- `deformable_gym/assets/objects/mjcf/insole_fixed.xml`: Removed `<extension>` block with `mujoco.elasticity.solid` plugin declaration, replaced `<plugin plugin="mujoco.elasticity.solid">` element with `<elasticity young="1e4" damping="1e-4" poisson="0.1"/>`
- `deformable_gym/assets/objects/mjcf/pillow_fixed.xml`: Same change, with `young="2000"` preserved from the original file

## Reference

- MuJoCo 3.2.4 changelog: https://mujoco.readthedocs.io/en/stable/changelog.html#version-3-2-4-oct-15-2024
- Example from MuJoCo docs: https://github.com/google-deepmind/mujoco/blob/main/model/flex/floppy.xml